### PR TITLE
Disable ci for merge result

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,6 +1,6 @@
 name: Backend
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,6 +1,6 @@
 name: Frontend
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build:


### PR DESCRIPTION
It is not required do run CI for the merge result, because PRs have to be up to date to be merged.